### PR TITLE
Default target build to javascript.

### DIFF
--- a/packages/vite-gleam/src/index.ts
+++ b/packages/vite-gleam/src/index.ts
@@ -36,8 +36,8 @@ async function makeDeps(path: string, o: Record<string, string> = {}) {
 
 export async function build() {
   if (!gleam_config) throw new Error("gleam.toml not found");
-  console.log("$ gleam build");
-  const out = execSync("gleam build", { encoding: "utf8" });
+  console.log("$ gleam build --target=javascript");
+  const out = execSync("gleam build --target=javascript", { encoding: "utf8" });
   console.log(out);
 
   const path = `./build/dev/javascript/${gleam_config?.name}`;
@@ -71,7 +71,7 @@ export default async function gleamVite(): Promise<Plugin> {
       if (!origin) origin = [];
       else if (typeof origin !== "object") origin = [origin];
 
-      (<string[]> origin).push("build/**");
+      (<string[]>origin).push("build/**");
       config.build.watch!.exclude = origin;
     },
     async buildStart() {


### PR DESCRIPTION
I've ran into an issue where I was getting an error from the plugin
```
error when starting dev server:                                                  
Error: ENOENT: no such file or directory, scandir './build/dev/javascript/app_name'     
```
and it took me a while to figure out that I was missing target=javascript in my `gleam.toml`. Would it make sense to default it to javascript? If so, here's a PR :smile: 